### PR TITLE
Added WiFi SSID Check

### DIFF
--- a/lib/pymakr-view.js
+++ b/lib/pymakr-view.js
@@ -66,6 +66,8 @@ export default class PymakrView {
     this.option_get_version.innerHTML = 'Get firmware version';
     this.option_get_serial = this.button_more_sub.appendChild(document.createElement('div'))
     this.option_get_serial.innerHTML = 'Get serial ports';
+	this.option_get_wifi = this.button_more_sub.appendChild(document.createElement('div'))
+	this.option_get_wifi.innerHTML = 'Get WiFi AP SSID';
 
 
     this.element.appendChild(topbar);
@@ -151,6 +153,10 @@ export default class PymakrView {
           _this.terminal.writePrompt()
         }
       })
+    }
+
+	this.option_get_wifi.onclick = function(){
+      _this.pyboard.send("from network import WLAN; from binascii import hexlify; from os import uname; wlan = WLAN(); mac = hexlify(wlan.mac()).decode('ascii'); device = uname().sysname;print('\n');print('WiFi AP SSID: %(device)s-wlan-%(mac)s' % {'device': device, 'mac': mac[len(mac)-4:len(mac)]})\r\n")
     }
 
     topbar.onclick = function(){


### PR DESCRIPTION
Add button for WiFi SSID to Pymakr Atom. Allows a user to query the device's WLAN access point SSID when first setting the device up. Useful when in a room of many people trying to determine their WiFi AP SSID.