### PR TITLE
 Allowing using local DNS names as address in settings

### DIFF
--- a/lib/main/settings-wrapper.js
+++ b/lib/main/settings-wrapper.js
@@ -4,6 +4,7 @@ import ApiWrapper from './api-wrapper.js';
 import Logger from '../helpers/logger.js'
 import Config from '../config.js'
 var fs = require('fs');
+const dns = require('dns');
 
 export default class SettingsWrapper extends EventEmitter {
   constructor() {
@@ -80,7 +81,10 @@ export default class SettingsWrapper extends EventEmitter {
   }
 
   refreshGlobalConfig(){
-    this.address = this.api.config('address')
+    self = this;
+    ip_addr = dns.lookup(this.api.config('address'), (err, address, family) => {
+      self.address = address;
+    });
     this.username = this.api.config('username')
     this.password = this.api.config('password')
     this.sync_folder = this.api.config('sync_folder')


### PR DESCRIPTION
As per the title of this PR, this patch allows using local DNS names as address in project or global settings. This comes handy when mDNS is used to advertise the telnet service in uPy.