### PR TITLE
Minimum atom version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.5.5 - Compatibility update
+* Updated supported Atom versions (>=1.41.0)
+
 ## 1.5.4 - Compatibility update
 * Binaries removed for older Atom versions, significantly reducing package size (50%).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pymakr",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "repository": "https://github.com/pycom/pymakr-atom",
   "license": "GPL-3.0",
   "engines": {
-    "atom": ">=1.40.0 <=1.43.0",
+    "atom": ">=1.41.0 <=1.43.0",
     "node": ">=6.3.0 <=7.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pymakr",
   "main": "./lib/main.js",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Adds a REPL console to Atom that connects to your Pycom board. It can run code on the board or synchronize your project files to it.",
   "keywords": [
     "Pycom",


### PR DESCRIPTION
Fixed minimum Atom version required to run Pymakr.
It must be >= 1.41.0, and not 1.40.0.

Pymakr 1.5.5 has been released with this fix. 