### PR TITLE
fix: fixed restart timeout

### DIFF
--- a/lib/connections/device.js
+++ b/lib/connections/device.js
@@ -221,7 +221,13 @@ export default class Device {
       _this.runner.selection(code, err => {
         if (err) {
           _this.logger.error('Failed to send and execute codeblock');
-        } else if (cb) cb();
+        } else if (cb) {
+          try {
+            cb();
+          } catch (e) {
+            // do nothing
+          }
+        }
       });
     }
   }

--- a/lib/helpers/commands.js
+++ b/lib/helpers/commands.js
@@ -186,7 +186,7 @@ export default class Commands {
   async formatFlash() {
     const _this = this;
     this.terminal.writeln('Formating flash storage...');
-     const command = "import os; os.fsformat('/flash');";
+    const command = "import os; os.fsformat('/flash');";
     this.busy = true;
     this.pyboard.run(
       command,
@@ -200,13 +200,19 @@ export default class Commands {
   }
 
   async reset() {
-    this.terminal.writeln('import machine; machine.reset();');
+    const _this = this;
+    this.terminal.writeln('Rebooting...');
     const command = 'import machine; machine.reset()';
-    try {
-      await this.getCommandAsync(command);
-    } catch (e) {
-      console.error(e);
-    }
+    this.busy = true;
+    this.pyboard.run(
+      command,
+      () => {
+        _this.busy = false;
+      },
+      err => {
+        _this.terminal.writelnAndPrompt(err);
+      },
+    );
   }
 
   async getFreeRam() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2484,8 +2484,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2506,14 +2505,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2528,20 +2525,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2658,8 +2652,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2671,7 +2664,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2686,7 +2678,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2694,14 +2685,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2720,7 +2709,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2808,8 +2796,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2821,7 +2808,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2907,8 +2893,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2944,7 +2929,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2964,7 +2948,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3008,14 +2991,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },


### PR DESCRIPTION
Fixed a timeout error when restart device is triggered. The device itself is successfully restarted anyway, but with a little bit of delay followed by a timeout exception printed in the logs. Now it's a way quicker and with no errors.