### PR TITLE
Pb 892 resizer fix

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -213,7 +213,7 @@ export default class Config {
         default: 14,
         title: "REPL font size",
         description:
-          "Changes the terminal font size (requires restart Atom).",
+          "Changes the terminal font size.",
         order: 14,
       },
     };

--- a/lib/connections/device.js
+++ b/lib/connections/device.js
@@ -190,6 +190,7 @@ export default class Device {
 
   close() {
     // close terminal tab
+    this.terminal.xterm.dispose();
     this.disconnect();
     this.view.removeConnectionTab(this.address);
   }

--- a/lib/pymakr.js
+++ b/lib/pymakr.js
@@ -56,11 +56,6 @@ export default class Pymakr extends EventEmitter {
       } else {
         $('#pymakr').addClass('light');
         $('.pymakr-status-bar').addClass('light');
-        _this.devices.forEach(device => {
-          device.terminal.xterm.setOption('theme', {
-            background: 'red !important',
-          });
-        });
         $('.pymakr-logo').attr(
           'src',
           `${this.api.getPackagePath()}/styles/assets/logo-navy.png`,
@@ -102,7 +97,6 @@ export default class Pymakr extends EventEmitter {
         const { commands } = _this.selectedDevice;
         await commands.prepare();
         await commands.formatFlash();
-       
       }
     });
   }

--- a/lib/views/action-view.js
+++ b/lib/views/action-view.js
@@ -1,6 +1,6 @@
 'use babel';
 
-import '../../node_modules/xterm/dist/addons/fit/fit';
+
 import ApiWrapper from '../wrappers/api-wrapper';
 import Logger from '../helpers/logger';
 
@@ -43,6 +43,7 @@ export default class ActionView extends EventEmitter {
     this.runActionButton = $('#iab-run');
     this.runActionDialog = $('#action-dialog-run');
 
+    const platform = process.platform;
     const tooltipOptions = title => ({
       title,
       trigger: 'hover',
@@ -51,16 +52,35 @@ export default class ActionView extends EventEmitter {
     });
     atom.tooltips.add(
       this.connect,
-      tooltipOptions('Connect/Disconnect'),
+      tooltipOptions(
+        `Connect/Disconnect <span class="keystroke">${
+          platform === 'darwin'
+            ? '⌃⌥C'
+            : 'ctrl+alt+c'
+        }</span> <span class="keystroke">${
+          platform === 'darwin'
+            ? '⌃⌥D'
+            : 'ctrl+alt+d'
+        }</span>`,
+      ),
     );
-    atom.tooltips.add(this.run, tooltipOptions('Run selected file'));
+    atom.tooltips.add(
+      this.run,
+      tooltipOptions(
+        `Run selected file <span class="keystroke">${platform==='darwin' ? '⌃⌥R' : 'ctrl+alt+r'}</span>`,
+      ),
+    );
     atom.tooltips.add(
       this.download,
       tooltipOptions('Download from device'),
     );
     atom.tooltips.add(
       this.upload,
-      tooltipOptions('Upload project to device'),
+      tooltipOptions(
+        `Upload project to device <span class="keystroke">${
+          platform === 'darwin' ? '⌃⌥S' : 'ctrl+alt+s'
+        }</span>`,
+      ),
     );
     atom.tooltips.add(this.info, tooltipOptions('Get device info'));
     this.bindOnClicks();

--- a/lib/views/info-view.js
+++ b/lib/views/info-view.js
@@ -1,6 +1,6 @@
 'use babel';
 
-import '../../node_modules/xterm/dist/addons/fit/fit';
+
 import ApiWrapper from '../wrappers/api-wrapper';
 
 const EventEmitter = require('events');

--- a/lib/views/overlay-view.js
+++ b/lib/views/overlay-view.js
@@ -1,7 +1,7 @@
 'use babel';
 
 import { Pane } from 'atom';
-import '../../node_modules/xterm/dist/addons/fit/fit';
+
 import Term from './terminal';
 import Pyserial from '../connections/pyserial';
 import ApiWrapper from '../wrappers/api-wrapper';

--- a/lib/views/panel-view.js
+++ b/lib/views/panel-view.js
@@ -1,6 +1,5 @@
 'use babel';
 
-import '../../node_modules/xterm/dist/addons/fit/fit';
 import ApiWrapper from '../wrappers/api-wrapper';
 import Logger from '../helpers/logger';
 import Utils from '../helpers/utils';
@@ -164,35 +163,29 @@ export default class PanelView extends EventEmitter {
     });
   }
 
+  resizeTerminals(newHeight) {
+    if (this.selectedDevice) {
+      const terminals = document.querySelectorAll('.device-terminal');
+      terminals.forEach(term => {
+        term.style.height = `${newHeight - 24}px`;
+      });
+
+      this.selectedDevice.terminal.fit.fit();
+    }
+  }
+
   initResize(resizer) {
     const _this = this;
     let startY = 0;
     const startRows = Config.constants().term_rows.default;
     const currentFontSize = _this.settings.font_size;
-    const lineHeight = currentFontSize + 8;
-    let startTermHeight = startRows * lineHeight;
-    let startHeight = startRows * lineHeight + 6;
-
-    let newTermHeight = startTermHeight;
-    let roundRows = Math.floor(
-      (startHeight - 2 * currentFontSize) / lineHeight,
-    );
+    const lineHeight = currentFontSize;
+    let startHeight = startRows * lineHeight;
+    let roundRows = Math.floor(startHeight / lineHeight);
     _this.element.height(`${startHeight}px`);
-
-    if (_this.selectedDevice) {
-      _this.selectedDevice.resizeAllTerminals(
-        newTermHeight,
-        roundRows - 1,
-      );
-      _this.lastRows = roundRows;
-    }
-
     function onMouseDown(e) {
       startY = e.clientY;
       startHeight = parseInt(_this.element.height(), 10) + 6;
-      if (_this.selectedDevice) {
-        startTermHeight = _this.selectedDevice.terminal.getHeight();
-      }
       document.documentElement.addEventListener(
         'mousemove',
         onMouseMove,
@@ -205,20 +198,11 @@ export default class PanelView extends EventEmitter {
       );
     }
     function onMouseMove(e) {
-      const newHeight = startHeight + startY - e.clientY;
-      newTermHeight = startTermHeight + startY - e.clientY;
-      roundRows = Math.floor(
-        (newHeight - 2 * currentFontSize) / lineHeight,
-      );
-
+      let newHeight = startHeight + startY - e.clientY;
+      roundRows = Math.floor(newHeight / lineHeight);
+      newHeight = roundRows * lineHeight + 50;
       _this.element.height(`${newHeight}px`);
-      if (_this.selectedDevice) {
-        _this.selectedDevice.resizeAllTerminals(
-          newTermHeight,
-          roundRows + 1,
-        );
-        _this.lastRows = roundRows;
-      }
+      _this.resizeTerminals(newHeight);
     }
 
     function stopDrag() {
@@ -248,14 +232,8 @@ export default class PanelView extends EventEmitter {
           roundRows = Math.floor(
             (height - 2 * currentFontSize) / lineHeight,
           );
-          if (_this.selectedDevice) {
-            _this.selectedDevice.resizeAllTerminals(
-              newTermHeight,
-              roundRows + 1,
-            );
-            _this.lastRows = roundRows;
-          }
         }
+        _this.resizeTerminals(height);
         previousHeight = height;
       },
     );

--- a/lib/views/sidebar-view.js
+++ b/lib/views/sidebar-view.js
@@ -1,6 +1,6 @@
 'use babel';
 
-import '../../node_modules/xterm/dist/addons/fit/fit';
+
 import ApiWrapper from '../wrappers/api-wrapper';
 import Logger from '../helpers/logger';
 

--- a/lib/views/snippets-view.js
+++ b/lib/views/snippets-view.js
@@ -1,7 +1,7 @@
 'use babel';
 
 import { Pane } from 'atom';
-import '../../node_modules/xterm/dist/addons/fit/fit';
+
 import Term from './terminal';
 import Pyserial from '../connections/pyserial';
 import ApiWrapper from '../wrappers/api-wrapper';

--- a/lib/views/terminal.js
+++ b/lib/views/terminal.js
@@ -1,7 +1,8 @@
 'use babel';
 
 // let Terminal = require('xterm')
-import Terminal from '../../node_modules/xterm/lib/xterm';
+import { Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
 import Logger from '../helpers/logger';
 import Config from '../config';
 import ApiWrapper from '../wrappers/api-wrapper';
@@ -17,29 +18,46 @@ export default class Term {
     this.onMessage = function() {};
     this.term_rows = Config.constants().term_rows;
     this.lastWrite = '';
+    const fontSize = atom.config.get('pymakr.font_size');
+    this.fontSize = parseInt(fontSize);
     this.lastRows = this.term_rows.default;
     this.startY = null;
     const _this = this;
-
+    this.fit = new FitAddon();
     this.xterm = new Terminal({
       cursorBlink: true,
+      fontSize: fontSize || 14,
       rows: this.term_rows.default,
       cols: 120,
+      rendererType: 'dom',
       scrollback: 5000,
     });
-
-    this.xterm.on('key', (key, e) => {
-      _this.termKeyPress(key, e);
-    });
-
+    this.xterm.loadAddon(this.fit);
     // for copy-paste with cmd key
     this.element.on('keydown', e => {
       if (_this.isActionKey(e)) {
         _this.termKeyPress('', e);
       }
     });
+    this.xterm.onKey(e => {
+      _this.termKeyPress(e.key, e.domEvent);
+    });
+    this.xterm.open(this.element_original);
+    this.fit.fit();
 
-    this.xterm.open(this.element_original, true);
+    atom.config.observe('pymakr.font_size', newValue => {
+      try {
+        let newFontSize = newValue || 14;
+        if (newValue > 50) newFontSize = 50;
+        else if (newValue < 14) newFontSize = 14;
+        _this.fontSize = parseInt(newFontSize);
+        _this.xterm.setOption('fontSize', _this.fontSize);
+        _this.fit.fit();
+      } catch (e) {
+        atom.notifications.addError('Invalid font size.');
+        atom.config.set(`pymakr.font_size`, 14);
+      }
+    });
   }
 
   setRows(pixels, rows) {
@@ -52,12 +70,10 @@ export default class Term {
   }
 
   setHeight(height, rows) {
-    const fontSize = atom.config.get('pymakr.font_size');
-    const fontSizeInt = parseInt(fontSize);
     this.last_height = this.element_original.style.height;
     this.element_original.style.height = `${height}px`;
     const fontMeasurement = $('.font-size-measurement');
-    fontMeasurement.css('font-size', `${fontSizeInt}px`);
+    fontMeasurement.css('font-size', `${this.fontSize}px`);
     const terminalWidth = $('#pymakr').innerWidth();
     const sidebarWidth = $('#pymakr-left-panel').width();
     const availableWidth = terminalWidth - sidebarWidth;

--- a/lib/wrappers/api-wrapper.js
+++ b/lib/wrappers/api-wrapper.js
@@ -6,24 +6,6 @@ $ = require('jquery');
 
 let projectPath = '';
 export default class ApiWrapper {
-  constructor(settings) {
-    atom.config.observe('pymakr.font_size', newValue => {
-      try {
-        let fontSize = newValue || 14;
-        if (fontSize > 50) fontSize = 50;
-        const fontSizeInt = parseInt(fontSize);
-
-        $('#pymakr-terminal-placeholder').css(
-          'font-size',
-          `${fontSizeInt}px`,
-        );
-      } catch (e) {
-        atom.notifications.addError('Invalid font size.');
-        atom.config.set(`pymakr.font_size`, 14);
-      }
-    });
-  }
-
   config(key) {
     return atom.config.get(`pymakr.${key}`);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pymakr",
-  "version": "1.5.6",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7133,9 +7133,14 @@
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "xterm": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-2.9.2.tgz",
-      "integrity": "sha512-mdfPk9nY6WmKkMDIZUL6xVIpJoP6JLv3mQ2hA490e2DboUlTWt2f60cTnTT20ZYFU11mx9OgVCcqhDI7vOAQ5Q=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.4.0.tgz",
+      "integrity": "sha512-JGIpigWM3EBWvnS3rtBuefkiToIILSK1HYMXy4BCsUpO+O4UeeV+/U1AdAXgCB6qJrnPNb7yLgBsVCQUNMteig=="
+    },
+    "xterm-addon-fit": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.3.0.tgz",
+      "integrity": "sha512-kvkiqHVrnMXgyCH9Xn0BOBJ7XaWC/4BgpSWQy3SueqximgW630t/QOankgqkvk11iTOCwWdAY9DTyQBXUMN3lw=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "tar": ">=2.2.2",
     "telnet-client": "^0.16.1",
     "utf8": "^3.0.0",
-    "xterm": "^2.9.2"
+    "xterm": "^4.4.0",
+    "xterm-addon-fit": "^0.3.0"
   },
   "scripts": {
     "watch": "onchange '**/*.js' '**/*.html'  '**/*.less' -- sh scripts/restart-atom.sh",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pymakr",
   "main": "./lib/main.js",
-  "version": "1.5.6",
+  "version": "2.0.0",
   "description": "Adds a REPL console to Atom that connects to your Pycom board. It can run code on the board or synchronize your project files to it.",
   "keywords": [
     "Pycom",

--- a/styles/pymakr.less
+++ b/styles/pymakr.less
@@ -122,10 +122,6 @@
         .terminal-cursor {
         background-color: transparent;
       }
-      .terminal:not(.xterm-cursor-style-underline):not(.xterm-cursor-style-bar).focus.xterm-cursor-blink-off
-        .terminal-cursor {
-        background-color: red;
-      }
     }
 
     #pymakr-left-panel .left-button.disabled {

--- a/styles/pymakr.less
+++ b/styles/pymakr.less
@@ -98,18 +98,18 @@
     }
 
     #pymakr-terminal-area {
-      background-color: @input-background-color !important;
-      color: #2c313a !important;
       border: 1px solid #c5cad3 !important;
       border-left: none !important;
+      background-color: @input-background-color !important;
       .xterm-selection {
-        background-color: blue !important;
         div {
           background-color: gray !important;
         }
       }
+
       .xterm-rows {
         color: @text-color !important;
+        background-color: @input-background-color !important;
       }
       .terminal .terminal-cursor {
         outline: 1px solid #2c313a;
@@ -121,6 +121,10 @@
       .terminal:not(.xterm-cursor-style-underline):not(.xterm-cursor-style-bar).focus.xterm-cursor-blink-on
         .terminal-cursor {
         background-color: transparent;
+      }
+      .terminal:not(.xterm-cursor-style-underline):not(.xterm-cursor-style-bar).focus.xterm-cursor-blink-off
+        .terminal-cursor {
+        background-color: red;
       }
     }
 
@@ -151,7 +155,7 @@
     left: 0px;
     right: 0px;
     bottom: 0px;
-    background-color: #000000;
+    background-color: @base-border-color;
     opacity: 0.5;
     z-index: 1;
   }
@@ -475,6 +479,16 @@
     span.fa {
       margin: 0 3px;
     }
+    &.left-button {
+      span {
+        position: absolute;
+        transform: translateX(-50%) translateY(-50%);
+        z-index: 1;
+        margin-left: 0px;
+        left: 50%;
+        top: 50%;
+      }
+    }
     &.has-sub {
       margin-right: 18px;
       cursor: default;
@@ -590,7 +604,7 @@
     }
   }
   #pymakr-terminal-area {
-    background: @input-background-color;
+    background: @base-border-color !important;
     padding-left: 5px;
     height: 100%;
     margin-left: 59px;
@@ -602,14 +616,16 @@
       padding-left: 6px;
       &.open {
         display: block;
+        flex: 1;
       }
-      #pymakr #pymakr-terminal-area{
+      #pymakr #pymakr-terminal-area {
         background-color: transparent !important;
       }
     }
     div.device-terminal {
       display: none;
       &.open {
+        height: 100%;
         display: block;
       }
     }
@@ -674,7 +690,7 @@
     width: 60px;
     display: flex;
     flex-direction: column;
-
+    z-index: 0;
     .left-button {
       position: relative;
       flex: 1;
@@ -724,7 +740,7 @@
           position: absolute;
           transform: translateX(-50%) translateY(-50%);
           z-index: -1;
-          margin-left: 3px;
+          margin-left: 3px !important;
           opacity: 0;
           left: 50%;
           top: 50%;
@@ -994,10 +1010,31 @@ div.pymakr-feedback {
   /* On OS X this is required in order for the scroll bar to appear fully opaque */
   background-color: @input-background-color !important;
   overflow-y: scroll;
+  overflow-y: scroll;
+  cursor: default;
+  position: absolute !important;
+  right: 0;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  z-index: -1;
 }
 
 #pymakr-terminal-area {
   .xterm-rows {
     padding-left: 6px !important;
   }
+}
+
+.xterm-cursor.xterm-cursor-blink.xterm-cursor-block {
+  border: 1px solid @text-color !important;
+}
+.xterm-dom-renderer-owner-1
+  .xterm-rows:not(.xterm-focus)
+  .xterm-cursor.xterm-cursor-block {
+  outline: 1px solid @text-color-subtle !important;
+}
+.xterm-rows {
+  color: @text-color-highlight !important;
+  background-color: @base-border-color !important;
 }

--- a/styles/xterm.css
+++ b/styles/xterm.css
@@ -163,7 +163,6 @@
 
 .terminal .xterm-viewport {
   /* On OS X this is required in order for the scroll bar to appear fully opaque */
-  background-color: #000;
   overflow-y: scroll;
 }
 


### PR DESCRIPTION
Fix for the Pymakr resizer. I've updated xterm from 2 to 4 so I could make use of Fit addon for xterm. This addon will ensure the terminal is always 100% height and width. Sometimes, depending on Pymakr panel height (terminal's parent), there might be a little space underneath the terminal because, in that case, there's no space available to put one more line. Now changing font size has an immediate effect, no needs to restart atom anymore. I also added a little badge on buttons' tooltips showing the correspondent shortcut for that command. 

Since now I could finally manage to update the xterm to >3, the warning security might be gone after merging this PR. 

<img width="318" alt="image" src="https://user-images.githubusercontent.com/15652671/74049240-0391c280-49d4-11ea-9a0d-6dda670f2b32.png">
