### PR TITLE
Improved Resizer

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -17,7 +17,7 @@ export default class Config {
       fast_upload_batch_multiplier: 4, // multiplier for upload_batch_size when fast_upload is active
       hash_check_max_size: 200, // in kb
       compressed_files_folder: "pymakr_uploads_compressed", // dynamically generated and removed again after upload
-      term_rows: { default: 13, max: 90, min: 1 },
+      term_rows: { default: 18, max: 90, min: 1 },
       help_text:
         "Pymakr Atom Package Help. Functions:\r\n" +
         "- Disconnect        : Disconnects from the board\r\n" +

--- a/lib/main.js
+++ b/lib/main.js
@@ -28,16 +28,14 @@ export default {
         _this.view = new PanelView(
           settings,
           state.viewState,
-          null,
-          _this.isDark,
+          null
         );
         _this.view.addPanel();
         _this.view.build();
         _this.pymakr = new Pymakr(
           state.viewState,
           _this.view,
-          settings,
-          _this.isDark,
+          settings
         );
         _this.buildStatusBar();
         // Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable

--- a/lib/pymakr.js
+++ b/lib/pymakr.js
@@ -497,6 +497,7 @@ export default class Pymakr extends EventEmitter {
       this.api.selectFirstProject();
     }
     finalDevice.select();
+    this.view.initTerminalHeight();
     $('#pymakr-info-close').click();
   }
 
@@ -563,6 +564,7 @@ export default class Pymakr extends EventEmitter {
     device.connect(
       () => {
         _this.view.setDeviceStatus(device.finalAddress, 'connected');
+        _this.view.initTerminalHeight();
       },
       () => {
         _this.view.setDeviceStatus(
@@ -629,6 +631,7 @@ export default class Pymakr extends EventEmitter {
   showPanel() {
     this.view.showPanel();
     this.setButtonState();
+    this.view.initTerminalHeight();
     this.connect();
   }
 

--- a/lib/views/info-view.html
+++ b/lib/views/info-view.html
@@ -74,19 +74,14 @@
       <div class="data">
         <span id="info-view-freeMemory">loading...</span
         >
-        <!-- <button id="info-button-free-memory">Format</button> -->
       </div>
     </div>
     <div class="row">
       <div class="label">Memory status</div>
       <div class="data">
         <span id="info-view-freeRam">loading...</span>
-        <!-- <button id="info-button-free-ram">Collect</button> -->
       </div>
     </div>
 
-    <!-- <div class="row">
-      <button style="margin-left: 7px; margin-top: 12px" class="data" id="info-button-reboot">Reboot</button>
-    </div> -->
   </div>
 </div>

--- a/lib/views/panel-view.js
+++ b/lib/views/panel-view.js
@@ -35,6 +35,7 @@ export default class PanelView extends EventEmitter {
     this.selectedDevice = null;
     this.term_rows = Config.constants().term_rows;
     this.utils = new Utils(settings);
+    this.alreadyResized = false;
     const html = fs.readFileSync(
       `${_this.package_folder}/views/panel-view.html`,
     );
@@ -175,12 +176,18 @@ export default class PanelView extends EventEmitter {
   }
 
   initTerminalHeight() {
-    const startRows = Config.constants().term_rows.default;
-    const currentFontSize = this.settings.font_size;
-    const lineHeight = currentFontSize;
-    const startHeight = startRows * lineHeight;
-    this.element.height(`${startHeight}px`);
-    this.resizeTerminals(startHeight);
+    if (!this.alreadyResized) {
+      const startRows = Config.constants().term_rows.default;
+      const currentFontSize = this.settings.font_size;
+      const lineHeight = currentFontSize;
+      const startHeight = startRows * lineHeight;
+      this.element.height(`${startHeight}px`);
+      this.resizeTerminals(startHeight);
+      this.alreadyResized = true;
+    }else{
+      // terminal already open
+      this.resizeTerminals(this.element.height());
+    }
   }
 
   initResize(resizer) {

--- a/lib/views/panel-view.js
+++ b/lib/views/panel-view.js
@@ -167,22 +167,26 @@ export default class PanelView extends EventEmitter {
     if (this.selectedDevice) {
       const terminals = document.querySelectorAll('.device-terminal');
       terminals.forEach(term => {
-        term.style.height = `${newHeight - 24}px`;
+        term.style.height = `${newHeight - 30}px`;
       });
 
       this.selectedDevice.terminal.fit.fit();
     }
   }
 
+  initTerminalHeight() {
+    const startRows = Config.constants().term_rows.default;
+    const currentFontSize = this.settings.font_size;
+    const lineHeight = currentFontSize;
+    const startHeight = startRows * lineHeight;
+    this.element.height(`${startHeight}px`);
+    this.resizeTerminals(startHeight);
+  }
+
   initResize(resizer) {
     const _this = this;
     let startY = 0;
-    const startRows = Config.constants().term_rows.default;
-    const currentFontSize = _this.settings.font_size;
-    const lineHeight = currentFontSize;
-    let startHeight = startRows * lineHeight;
-    let roundRows = Math.floor(startHeight / lineHeight);
-    _this.element.height(`${startHeight}px`);
+    this.initTerminalHeight();
     function onMouseDown(e) {
       startY = e.clientY;
       startHeight = parseInt(_this.element.height(), 10) + 6;
@@ -198,9 +202,7 @@ export default class PanelView extends EventEmitter {
       );
     }
     function onMouseMove(e) {
-      let newHeight = startHeight + startY - e.clientY;
-      roundRows = Math.floor(newHeight / lineHeight);
-      newHeight = roundRows * lineHeight + 50;
+      const newHeight = startHeight + startY - e.clientY;
       _this.element.height(`${newHeight}px`);
       _this.resizeTerminals(newHeight);
     }
@@ -222,19 +224,11 @@ export default class PanelView extends EventEmitter {
     const erdUltraFast = elementResizeDetectorMaker({
       strategy: 'scroll',
     });
-    let previousHeight = 0;
     erdUltraFast.listenTo(
       document.getElementById('pymakr'),
       element => {
         const height = element.offsetHeight - 25;
-        if (previousHeight === height) {
-          // if only the width has been changed (horizontal resizing), to avoid performance issues
-          roundRows = Math.floor(
-            (height - 2 * currentFontSize) / lineHeight,
-          );
-        }
         _this.resizeTerminals(height);
-        previousHeight = height;
       },
     );
   }

--- a/lib/views/panel-view.js
+++ b/lib/views/panel-view.js
@@ -194,6 +194,7 @@ export default class PanelView extends EventEmitter {
     const _this = this;
     let startY = 0;
     this.initTerminalHeight();
+    let startHeight;
     function onMouseDown(e) {
       startY = e.clientY;
       startHeight = parseInt(_this.element.height(), 10) + 6;

--- a/styles/pymakr.less
+++ b/styles/pymakr.less
@@ -251,6 +251,8 @@
           .row {
             margin-bottom: 10px;
           }
+          padding-bottom: 16px;
+
         }
         .row {
           div {

--- a/styles/pymakr.less
+++ b/styles/pymakr.less
@@ -622,7 +622,8 @@
       display: none;
       &.open {
         height: 100%;
-        display: block;
+        align-items: flex-end;
+        display: flex;
       }
     }
   }


### PR DESCRIPTION
Improved UX from 'resizer', giving a smoother experience while resizing Pymakr. The terminal now has an anchor on the bottom of the available space, which means the line correction will now occur on the previous lines and not on the last anymore. 

### Then:
![](https://im3.ezgif.com/tmp/ezgif-3-2b0974fab204.gif)
### Now:
![](https://im3.ezgif.com/tmp/ezgif-3-7b0ded35403d.gif)
