### PR TITLE
Connection tabs scrollable

### DIFF
--- a/styles/pymakr.less
+++ b/styles/pymakr.less
@@ -376,7 +376,7 @@
     }
     #pymakr-connection-tabs {
       display: inherit;
-
+      overflow-x: scroll;
       div.pymakr-connection {
         position: relative;
         border: none;


### PR DESCRIPTION
The connection tabs are now scrollable. 

![](https://im3.ezgif.com/tmp/ezgif-3-991ac5c5f42a.gif)

This PR also fixes the connection tab overflow:
<img width="180" alt="image" src="https://user-images.githubusercontent.com/15652671/74169742-17376600-4c2c-11ea-9ee1-b60083cee5f8.png">
