### PR TITLE
Pb 893 toggle terminal fix

### DIFF
--- a/keymaps/pycom-sync.json
+++ b/keymaps/pycom-sync.json
@@ -2,7 +2,7 @@
   "atom-workspace": {
     "ctrl-alt-s": "pymakr:upload",
     "ctrl-shift-s": "pymakr:uploadFile",
-    "ctrl-alt-t": "pymakr:toggleREPL",
+    "ctrl-alt-t": "pymakr:toggle REPL",
     "ctrl-alt-c": "pymakr:connect",
     "ctrl-alt-d": "pymakr:disconnect",
     "ctrl-alt-r": "pymakr:run",

--- a/lib/pymakr.js
+++ b/lib/pymakr.js
@@ -643,10 +643,12 @@ export default class Pymakr extends EventEmitter {
 
   toggleVisibility() {
     if (this.view.visible) this.hidePanel();
-    else this.showPanel();
+    else {
+      this.showPanel();
+      this.autoConnect.start(null, true);
+    }
   }
 
-  // VSCode only
   toggleConnect() {
     if (this.selectedDevice) {
       if (this.selectedDevice.connected()) this.disconnect();

--- a/menus/pycom-sync.json
+++ b/menus/pycom-sync.json
@@ -6,7 +6,7 @@
         "submenu": [
           {
             "label": "Toggle Pycom Console",
-            "command": "pymakr:toggleREPL"
+            "command": "pymakr:toggle REPL"
           },
           {
             "label": "Run current file",
@@ -25,7 +25,7 @@
           "submenu": [
             {
               "label": "Toggle Pycom Console",
-              "command": "pymakr:toggleREPL"
+              "command": "pymakr:toggle REPL"
             },
             {
               "label": "Run current file",


### PR DESCRIPTION
This PR contains the following fixes:
- Toggle Command (Option + Control + T) not working.
- Multiple instances of Atom not being able to find devices on Pymakr. 
- Open on start setting not working. With that option disabled, Pymakr was not opening on Atom initialization but was not able to find devices too.


