### PR TITLE
Fix open PyJTAG bug

### DIFF
--- a/lib/pymakr.js
+++ b/lib/pymakr.js
@@ -445,8 +445,11 @@ export default class Pymakr extends EventEmitter {
   }
 
   findDevice(address) {
-
-    let i = -1;
+    let i = this.deviceAddresses.indexOf(address);
+    if (i > -1) {
+      return this.devices[i];
+    }
+    // PyyJTAG bug fix
     this.deviceAddresses.forEach((device, key)=> {if (device.includes(address)) i = key });
     if (i > -1) {
       return this.devices[i];

--- a/lib/pymakr.js
+++ b/lib/pymakr.js
@@ -445,12 +445,13 @@ export default class Pymakr extends EventEmitter {
   }
 
   findDevice(address) {
-    const i = this.deviceAddresses.indexOf(address);
+
+    let i = -1;
+    this.deviceAddresses.forEach((device, key)=> {if (device.includes(address)) i = key });
     if (i > -1) {
       return this.devices[i];
     }
-
-    return null;
+    return null
   }
 
   createDeviceIfNotExists(address) {
@@ -522,7 +523,7 @@ export default class Pymakr extends EventEmitter {
     );
     const addressArray = $.makeArray(addresses);
     const loopWithDelay = index => {
-      let finalIndex = index ? index : 0;
+      let finalIndex = index || 0;
       if (finalIndex < addressArray.length) {
         setTimeout(() => {
           addressArray[finalIndex].click();


### PR DESCRIPTION
Fixed a bug where Pymakr couldn't find the board by its name, causing unexpected tabs operations (closing, opening, closing all, opening all, tabs sync).

