### PR TITLE
Fixed xterm recent bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "tar": ">=2.2.2",
     "telnet-client": "^0.16.1",
     "utf8": "^3.0.0",
-    "xterm": "^4.4.0",
-    "xterm-addon-fit": "^0.3.0"
+    "xterm": "4.4.0",
+    "xterm-addon-fit": "0.3.0"
   },
   "scripts": {
     "watch": "onchange '**/*.js' '**/*.html'  '**/*.less' -- sh scripts/restart-atom.sh",


### PR DESCRIPTION
Recently, xterm.js has been updated and the new version (4.6.0) of it is breaking Pymakr. This PR contains an update in package.json that locks xterm.js to 4.4.0