### PR TITLE
Fixed invisible Pybytes label in Pybytes button

### DIFF
--- a/lib/views/panel-view.html
+++ b/lib/views/panel-view.html
@@ -1,7 +1,6 @@
 <div id="pymakr" class="pymakr pymakr-open">
   <div id="pymakr-resizer"></div>
   <span class="font-size-measurement">x</span>
-  <link href="css/chrome-tabs.css" rel="stylesheet" />
   <div id="pymakr-overlay-contents"></div>
 
   <div id="pycom-top-bar">

--- a/lib/views/sidebar-view.html
+++ b/lib/views/sidebar-view.html
@@ -51,9 +51,6 @@
     class="has-sub"
   >
     <div id="pybytes-logo" />
-    <span style="margin-bottom: 4px">
-      Pybytes
-    </span>
   </button>
   <button style="margin-left: -15px;" id="seemore" class="has-sub">
     <span style="margin-top: 1px;" class="fa fa-plus"></span> More

--- a/lib/views/sidebar-view.js
+++ b/lib/views/sidebar-view.js
@@ -40,8 +40,11 @@ export default class SideBar extends EventEmitter {
     $('#pybytes-logo').load(
       `${this.api.getPackagePath()}/styles/assets/pycom-icon.svg`,
     );
-    this.buttonPybytes = $('#pymakr #pybytes');
+    this.buttonPybytes = $('#pybytes');
+    const pybytesLabel = $('<span style="margin-bottom: 4px">Pybytes</span>');
     this.buttonPybytes.addClass('badge-new');
+    this.buttonPybytes.append(pybytesLabel);
+
     this.bindOnClicks();
   }
 


### PR DESCRIPTION
This PR contains the fix for the invisible Pybytes label in Pybytes button and also the not found console.error related to chrome-tabs.css