### PR TITLE
Feat configurable max scrollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.2.2](https://github.com/pycom/pymakr-atom/compare/v2.2.1...v2.2.2) (2022-01-31)
+
+
+### Bug Fixes
+
+* removed deprecated "synchronize project" ([7df8f8a](https://github.com/pycom/pymakr-atom/commit/7df8f8a4f61d1b756170bbf25d5b3a7d6142412d))
+
 ## [2.2.1](https://github.com/pycom/pymakr-atom/compare/v2.2.0...v2.2.1) (2022-01-13)
 
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -217,6 +217,13 @@ export default class Config {
           "Changes the terminal font size.",
         order: 14,
       },
+      scrollback: {
+        type: "number",
+        default: 5000,
+        title: "Scrollback",
+        description: "The max number lines to preserve in the terminal.",
+        order: 15
+      },
     };
   }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -221,7 +221,7 @@ export default class Config {
         type: "number",
         default: 5000,
         title: "Scrollback",
-        description: "The max number lines to preserve in the terminal.",
+        description: "The max number of lines to preserve in the terminal.",
         order: 15
       },
     };

--- a/lib/views/terminal.js
+++ b/lib/views/terminal.js
@@ -30,7 +30,7 @@ export default class Term {
       rows: this.term_rows.default,
       cols: 120,
       rendererType: 'dom',
-      scrollback: 5000,
+      scrollback: this.api.config('scrollback')
     });
     this.xterm.loadAddon(this.fit);
     // for copy-paste with cmd key

--- a/lib/wrappers/settings-wrapper.js
+++ b/lib/wrappers/settings-wrapper.js
@@ -126,6 +126,7 @@ export default class SettingsWrapper extends EventEmitter {
     this.auto_connect = this.api.config('auto_connect');
     this.py_ignore = this.api.config('py_ignore');
     this.fast_upload = this.api.config('fast_upload');
+    this.scrollback = this.api.config('scrollback');
     this.autoconnect_comport_manufacturers = this.api.config(
       'autoconnect_comport_manufacturers',
     );
@@ -242,6 +243,9 @@ export default class SettingsWrapper extends EventEmitter {
     if ('font_size' in this.project_config) {
       this.font_size = this.project_config.font_size;
     }
+    if('scrollback' in this.project_config) {
+      this.scrollback = this.project_config.scrollback
+    }
   }
 
   getDefaultProjectConfig() {
@@ -258,6 +262,7 @@ export default class SettingsWrapper extends EventEmitter {
       py_ignore: this.api.config('py_ignore'),
       fast_upload: this.api.config('fast_upload'),
       font_size: this.api.config('font_size'),
+      scrollback: this.api.config('scrollback'),      
     };
     return config;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pymakr",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pymakr",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pymakr",
   "main": "./lib/main.js",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Adds a REPL console to Atom that connects to your Pycom board. It can run code on the board or synchronize your project files to it.",
   "keywords": [
     "Pycom",


### PR DESCRIPTION
The terminal is currently locked to max 5000 lines of history. This patch makes the max scrollback lines configurable.

![image](https://user-images.githubusercontent.com/4153004/154921433-af15f677-27cf-4bcc-a6e2-2410643d9f8f.png)
